### PR TITLE
docs: fix simple typo, commecrial -> commercial

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     usually your /usr/bin directory.
 
  Licensing:
-    This is distributed unider the Creative Commons 3.0 Non-commecrial,
+    This is distributed unider the Creative Commons 3.0 Non-commercial,
     Attribution, Share-Alike license. You can use the code for noncommercial
     purposes. You may NOT sell it. If you do use it, then you must make an
     attribution to me (i.e. Include my name and thank me for the hours I spent

--- a/nest.py
+++ b/nest.py
@@ -7,7 +7,7 @@
 #    'nest.py help' will tell you what to do and how to do it
 #
 # Licensing:
-#    This is distributed unider the Creative Commons 3.0 Non-commecrial,
+#    This is distributed unider the Creative Commons 3.0 Non-commercial,
 #    Attribution, Share-Alike license. You can use the code for noncommercial
 #    purposes. You may NOT sell it. If you do use it, then you must make an
 #    attribution to me (i.e. Include my name and thank me for the hours I spent


### PR DESCRIPTION
There is a small typo in README.md, nest.py.

Should read `commercial` rather than `commecrial`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md